### PR TITLE
Add link_to for issue number column 'ID'

### DIFF
--- a/app/helpers/mail_reminders_helper.rb
+++ b/app/helpers/mail_reminders_helper.rb
@@ -27,6 +27,8 @@ module MailRemindersHelper
     when 'Fixnum', 'Float'
       if column.name == :done_ratio
         progress_bar(value, :width => '80px')
+	  elsif column.name == :id
+	    link_to h(value.to_s), issue_url(issue)
       else
         h(value.to_s)
       end


### PR DESCRIPTION
Helpful to have a link to the issue without requiring the subject to be included in the query report. 