### PR TITLE
Don't send reminder at every run

### DIFF
--- a/app/helpers/mail_reminders_helper.rb
+++ b/app/helpers/mail_reminders_helper.rb
@@ -1,4 +1,7 @@
 module MailRemindersHelper
+
+  include QueriesHelper
+
   def queries_for_options(project_id)
     # Project specific queries and global queries
     IssueQuery.visible.order("#{Query.table_name}.name ASC").
@@ -49,7 +52,8 @@ module MailRemindersHelper
     when 'Issue'
       link_to value.subject, issue_url(value)
     else
-      h(value)
+      column_content(column, issue)
+      # h(value)
     end
   end
 end

--- a/app/models/mail_reminder.rb
+++ b/app/models/mail_reminder.rb
@@ -63,6 +63,16 @@ class MailReminder < ActiveRecord::Base
     end
   end
 
+  def last_execute
+    result = Time.now
+    if executed_at.nil? || (updated_at > executed_at)
+      result = updated_at
+    else
+      result = executed_at
+    end
+    return result
+  end
+
   def execute?
     case interval
     when "daily"
@@ -77,22 +87,21 @@ class MailReminder < ActiveRecord::Base
   end
 
   def execute_daily?
-    comparision_date = Time.now
-    if executed_at.nil? || (updated_at > executed_at)
-      comparision_date = updated_at
-    else
-      comparision_date = executed_at
-    end
-
-    diff = ((Time.now - comparision_date) / 1.day).round.to_i
+    return false if last_execute.to_date == DateTime.current.to_date
+    
+    diff = ((Time.now - last_execute) / 1.day).round.to_i
     return diff >= interval_value + 1
   end
 
   def execute_weekly?
+    return false if last_execute.to_date == DateTime.current.to_date
+
     return Time.now.wday == interval_value
   end
 
   def execute_monthly?
+    return false if last_execute.to_date == DateTime.current.to_date
+
     if Time::days_in_month(Time.now.month) < interval_value
       if Time.now.mday == Time.days_in_month(Time.now.month)
         return true

--- a/app/views/mail_reminder_mailer/issues_reminder.html.erb
+++ b/app/views/mail_reminder_mailer/issues_reminder.html.erb
@@ -4,6 +4,14 @@
 <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
 <% headers[:skip_premailer] = nil if headers[:skip_premailer] %>
 <%= stylesheet_link_tag '/stylesheets/application', 'jquery/jquery-ui-1.11.0', 'application', :media => 'all' %>
+
+<%= stylesheet_link_tag 'jquery/jquery-ui-1.11.0', 'application', 'responsive', :media => 'all' %>
+<%= stylesheet_link_tag 'rtl', :media => 'all' if l(:direction) == 'rtl' %>
+<%= javascript_heads %>
+<%= heads_for_theme %>
+<%= call_hook :view_layouts_base_html_head %>
+<!-- page specific tags -->
+<%= yield :header_tags -%>
 </head>
 <body>
 <% if Setting.plugin_redmine_mail_reminder['issue_reminder_mail_header'].present? %>

--- a/lib/tasks/reminder.rake
+++ b/lib/tasks/reminder.rake
@@ -31,10 +31,13 @@ namespace :reminder do
             reject {|m| m.user.nil? || m.user.locked?}.
             each do |member|
               mail_data[member.user] << [rem.project, rem.query]
-              rem.executed_at = Time.now if args.test != "test"
-              rem.save
             end
         end
+        rem.executed_at = Time.now if args.test != "test"
+        rem.save
+
+        print "Project \"#{ rem.project.name }\" with query \"#{ rem.query.name }\" "
+        puts "\t done.".light_green
       end
 
       # Fixed: reminder mails are not sent when delivery_method is :async_smtp (#5058).

--- a/lib/tasks/reminder.rake
+++ b/lib/tasks/reminder.rake
@@ -35,9 +35,6 @@ namespace :reminder do
         end
         rem.executed_at = Time.now if args.test != "test"
         rem.save
-
-        print "Project \"#{ rem.project.name }\" with query \"#{ rem.query.name }\" "
-        puts "\t done.".light_green
       end
 
       # Fixed: reminder mails are not sent when delivery_method is :async_smtp (#5058).


### PR DESCRIPTION
If your cron execute more than once every day, each time, the plugin will send a reminder.
With this :

1. the plugin will check the last executed date of every reminder with the current date and won't send a new email if the reminder was already send for the date.
2. instead of updating the executed_at for each role for each mail (and don't if there is no one), the rake action will save the executed_at every time (and only once) the reminder is executed.